### PR TITLE
Fix broken link: Strange Loop talk

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -184,7 +184,7 @@ Comby is designed to support <a href="docs/overview#does-it-work-on-my-language"
             </div>
             <div className="column">
               <p>
-                Watch the <a href="docs/talks/strange-loop-2018">Strange Loop talk</a> to learn more about Comby.
+                Watch the <a href="https://www.youtube.com/watch?v=JMZLBB_BFNg&feature=emb_title">Strange Loop talk</a> to learn more about Comby.
               </p>
               <blockquote className="monotone">
                 <p>


### PR DESCRIPTION
This link is broken and gives 404 not found. Not sure whether or not your want link straight to YouTube here, but at least this is fixing the 404.